### PR TITLE
support for Alfresco Repository 5.2.g (& ignore POM errors in Eclipse)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <messages.path>acosix/simple-content-stores</messages.path>
         <messages.packageId>acosix.simple-content-stores</messages.packageId>
         <moduleId>acosix-simple-content-stores</moduleId>
+        <alfresco.distribution.version>5.2.g</alfresco.distribution.version>
+        <surf.version>6.11</surf.version>
     </properties>
 
     <repositories>
@@ -195,5 +197,80 @@
 
         </plugins>
 
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.alfresco.maven.plugin
+        								</groupId>
+        								<artifactId>
+        									alfresco-maven-plugin
+        								</artifactId>
+        								<versionRange>
+        									[1.1.1,)
+        								</versionRange>
+        								<goals>
+        									<goal>set-version</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									de.acosix.maven
+        								</groupId>
+        								<artifactId>
+        									jshint-maven-plugin
+        								</artifactId>
+        								<versionRange>
+        									[1.0.0,)
+        								</versionRange>
+        								<goals>
+        									<goal>jshint</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									de.acosix.alfresco.maven
+        								</groupId>
+        								<artifactId>
+        									de.acosix.alfresco.maven.plugins
+        								</artifactId>
+        								<versionRange>
+        									[1.0.0.2,)
+        								</versionRange>
+        								<goals>
+        									<goal>
+        										duplicateI18nResources
+        									</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/facade/CommonFacadingContentStore.java
+++ b/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/facade/CommonFacadingContentStore.java
@@ -15,7 +15,6 @@
  */
 package de.acosix.alfresco.simplecontentstores.repo.store.facade;
 
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,7 +27,6 @@ import org.alfresco.repo.content.UnsupportedContentUrlException;
 import org.alfresco.service.cmr.dictionary.DataTypeDefinition;
 import org.alfresco.service.cmr.dictionary.DictionaryService;
 import org.alfresco.service.cmr.dictionary.PropertyDefinition;
-import org.alfresco.service.cmr.repository.ContentIOException;
 import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.ContentWriter;
 import org.alfresco.service.namespace.NamespaceService;
@@ -206,25 +204,6 @@ public abstract class CommonFacadingContentStore implements ContentStore, Initia
         }
 
         return this.backingStore.getWriter(context);
-    }
-
-    /**
-     *
-     * {@inheritDoc}
-     */
-    @Override @SuppressWarnings("deprecation")
-    public void getUrls(final Date createdAfter, final Date createdBefore, final ContentUrlHandler handler) throws ContentIOException
-    {
-        this.backingStore.getUrls(createdAfter, createdBefore, handler);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override @SuppressWarnings("deprecation")
-    public void getUrls(final ContentUrlHandler handler) throws ContentIOException
-    {
-        this.backingStore.getUrls(handler);
     }
 
     /**

--- a/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/file/FileContentStore.java
+++ b/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/file/FileContentStore.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.Map;
@@ -408,19 +407,6 @@ public class FileContentStore extends AbstractContentStore
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Deprecated
-    @Override
-    public void getUrls(final Date createdAfter, final Date createdBefore, final ContentUrlHandler handler)
-    {
-        // recursively get all files within the root
-        this.getUrls(this.rootDirectory, handler, createdAfter, createdBefore);
-        // done
-        LOGGER.debug("Listed all content URLS: \n   store: {}", this);
-    }
-
-    /**
      *
      * {@inheritDoc}
      */
@@ -672,55 +658,5 @@ public class FileContentStore extends AbstractContentStore
         final String newContentUrl = sb.toString();
         // done
         return newContentUrl;
-    }
-
-    /**
-     * Returns a list of all files within the given directory and all subdirectories.
-     *
-     * @param directory
-     *            the current directory to get the files from
-     * @param handler
-     *            the callback to use for each URL
-     * @param createdAfter
-     *            only get URLs for content create after this date
-     * @param createdBefore
-     *            only get URLs for content created before this date
-     */
-    @Deprecated
-    protected void getUrls(final File directory, final ContentUrlHandler handler, final Date createdAfter, final Date createdBefore)
-    {
-        final File[] files = directory.listFiles();
-        if (files == null)
-        {
-            // the directory has disappeared
-            throw new ContentIOException("Failed list files in folder: " + directory);
-        }
-        for (final File file : files)
-        {
-            if (file.isDirectory())
-            {
-                // we have a subdirectory - recurse
-                this.getUrls(file, handler, createdAfter, createdBefore);
-            }
-            else
-            {
-                // check the created date of the file
-                final long lastModified = file.lastModified();
-                if (createdAfter != null && lastModified < createdAfter.getTime())
-                {
-                    // file is too old
-                    continue;
-                }
-                else if (createdBefore != null && lastModified > createdBefore.getTime())
-                {
-                    // file is too young
-                    continue;
-                }
-                // found a file - create the URL
-                final String contentUrl = this.makeContentUrl(file);
-                // Callback
-                handler.handle(contentUrl);
-            }
-        }
     }
 }

--- a/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/routing/MoveCapableCommonRoutingContentStore.java
+++ b/src/main/java/de/acosix/alfresco/simplecontentstores/repo/store/routing/MoveCapableCommonRoutingContentStore.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -361,39 +360,6 @@ public abstract class MoveCapableCommonRoutingContentStore<CD> implements Conten
 
         LOGGER.debug("Got writer and cache URL from store: \n\tContext: {}\n\tWriter:  {}\n\tStore:   {}", context, writer, store);
         return writer;
-    }
-
-    /**
-     *
-     * {@inheritDoc}
-     */
-    @Override
-    @SuppressWarnings("deprecation")
-    public void getUrls(final ContentUrlHandler handler) throws ContentIOException
-    {
-        this.getUrls(null, null, handler);
-    }
-
-    /**
-     *
-     * {@inheritDoc}
-     */
-    @Override
-    @SuppressWarnings("deprecation")
-    public void getUrls(final Date createdAfter, final Date createdBefore, final ContentUrlHandler handler) throws ContentIOException
-    {
-        final List<ContentStore> stores = this.getAllStores();
-        for (final ContentStore store : stores)
-        {
-            try
-            {
-                store.getUrls(createdAfter, createdBefore, handler);
-            }
-            catch (final UnsupportedOperationException e)
-            {
-                // Support of this is not mandatory
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Hi Axel, this PR might help you when moving to Alfresco Repository 5.2.g (latest community release, 201707 GA). Some overridden (deprecated) methods were removed because they are no longer part of the Java API. I'm using the property routed selector content store and it works great in the latest Alfresco using this "fix".